### PR TITLE
mkdist-linux: actually enable bz2 compression for tar

### DIFF
--- a/dist/mkdist-linux
+++ b/dist/mkdist-linux
@@ -38,4 +38,4 @@ exec "\${basedir}/target/release/game_controller_app" "\$@"
 EOF
 chmod a+x "${archivedir}/game_controller"
 
-tar -cf "${archive}" -C "$(dirname "${archivedir}")" $(basename "${archivedir}")
+tar -cjf "${archive}" -C "$(dirname "${archivedir}")" $(basename "${archivedir}")


### PR DESCRIPTION
`tar` command was missing the `-j` flag to actually enable bz2 compression on the output archive, so generated release tarballs were uncompressed, despite using the `*.tar.bz2` file extension